### PR TITLE
feat (GT-43): show PCAN device ID

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,7 +16,7 @@ alqtendpy==0.0.4
 https://github.com/pyinstaller/pyinstaller/archive/25eef61621a96fd42e8852a251d408ea57b9adb4.zip
 
 graham==0.1.11
--e git+https://github.com/gordon-epc/python-can@f451343f8b0991ee96e0849ce3198cc38977cebe#egg=python-can
+-e git+https://github.com/hardbyte/python-can@2ede107d67002c18463c5276b6a94cdb19fc8320#egg=python-can
 -e git+https://github.com/altendky/bitstruct@c1ff0e635257e7be0cf2e4dbdf8a12b8faf83e7f#egg=bitstruct
 
 Twisted==21.2.0

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -16,7 +16,7 @@ alqtendpy==0.0.4
 https://github.com/pyinstaller/pyinstaller/archive/25eef61621a96fd42e8852a251d408ea57b9adb4.zip
 
 graham==0.1.11
-python-can==3.3.2
+-e git+https://github.com/gordon-epc/python-can@f451343f8b0991ee96e0849ce3198cc38977cebe#egg=python-can
 -e git+https://github.com/altendky/bitstruct@c1ff0e635257e7be0cf2e4dbdf8a12b8faf83e7f#egg=bitstruct
 
 Twisted==21.2.0

--- a/requirements/base.linux.txt
+++ b/requirements/base.linux.txt
@@ -13,7 +13,7 @@
 -e git+https://github.com/eliben/pyelftools@27941c50fef8cff8ef991419511664154c8cdf52#egg=pyelftools  # via -r requirements/base.in, epyqlib
 -e git+https://github.com/altendky/pysunspec@d8072a8e3c04693fe2a657a90fc9d303037dd91c#egg=pysunspec  # via -r requirements/base.in, epcsunspecdemo
 -e git+https://github.com/altendky/pytest-twisted@6f04ba3ad806b3b40602999e71c28633c36d81f9#egg=pytest-twisted  # via -r requirements/base.in
--e git+https://github.com/gordon-epc/python-can@f451343f8b0991ee96e0849ce3198cc38977cebe#egg=python-can  # via -r requirements/base.in, epyqlib
+-e git+https://github.com/hardbyte/python-can@2ede107d67002c18463c5276b6a94cdb19fc8320#egg=python-can  # via -r requirements/base.in, epyqlib
 -e git+https://github.com/altendky/qt5reactor@ce3ea2dad6d71adb10cde79b64bc0c7d27e9139c#egg=qt5reactor  # via -r requirements/base.in, epyqlib
 alqtendpy==0.0.4          # via -r requirements/base.in, epyqlib
 altendpy==0.0.21          # via alqtendpy
@@ -45,7 +45,7 @@ graham==0.1.11            # via -r requirements/base.in, epyqlib
 greenlet==1.0.0           # via pytest-twisted
 hyperlink==21.0.0         # via treq, twisted
 idna==2.10                # via hyperlink, requests, twisted
-importlib-metadata==3.7.2  # via pint
+importlib-metadata==3.7.3  # via pint
 incremental==21.3.0       # via treq, twisted
 jinja2==2.11.3            # via altendpy
 jmespath==0.10.0          # via boto3, botocore

--- a/requirements/base.linux.txt
+++ b/requirements/base.linux.txt
@@ -13,8 +13,8 @@
 -e git+https://github.com/eliben/pyelftools@27941c50fef8cff8ef991419511664154c8cdf52#egg=pyelftools  # via -r requirements/base.in, epyqlib
 -e git+https://github.com/altendky/pysunspec@d8072a8e3c04693fe2a657a90fc9d303037dd91c#egg=pysunspec  # via -r requirements/base.in, epcsunspecdemo
 -e git+https://github.com/altendky/pytest-twisted@6f04ba3ad806b3b40602999e71c28633c36d81f9#egg=pytest-twisted  # via -r requirements/base.in
+-e git+https://github.com/gordon-epc/python-can@f451343f8b0991ee96e0849ce3198cc38977cebe#egg=python-can  # via -r requirements/base.in, epyqlib
 -e git+https://github.com/altendky/qt5reactor@ce3ea2dad6d71adb10cde79b64bc0c7d27e9139c#egg=qt5reactor  # via -r requirements/base.in, epyqlib
-aenum==3.0.0              # via python-can
 alqtendpy==0.0.4          # via -r requirements/base.in, epyqlib
 altendpy==0.0.21          # via alqtendpy
 altgraph==0.17            # via pyinstaller
@@ -36,7 +36,7 @@ constantly==15.1.0        # via twisted
 cryptography==3.4.6       # via pyopenssl, service-identity
 decorator==4.4.2          # via pytest-twisted
 docutils==0.15.2          # via botocore
-dulwich==0.20.19          # via epyqlib
+dulwich==0.20.20          # via epyqlib
 fab==3.0.0                # via epyqlib
 future==0.18.2            # via canmatrix
 gitdb==4.0.5              # via gitpython
@@ -45,7 +45,7 @@ graham==0.1.11            # via -r requirements/base.in, epyqlib
 greenlet==1.0.0           # via pytest-twisted
 hyperlink==21.0.0         # via treq, twisted
 idna==2.10                # via hyperlink, requests, twisted
-importlib-metadata==3.7.0  # via pint
+importlib-metadata==3.7.2  # via pint
 incremental==21.3.0       # via treq, twisted
 jinja2==2.11.3            # via altendpy
 jmespath==0.10.0          # via boto3, botocore
@@ -53,7 +53,8 @@ lxml==4.6.2               # via python-docx
 markupsafe==1.1.1         # via jinja2
 marshmallow==2.21.0       # via graham
 more-itertools==8.7.0     # via pytest
-mypy-extensions==0.4.3    # via black
+msgpack==1.0.2            # via python-can
+mypy-extensions==0.4.3    # via black, python-can
 natsort==5.4.1            # via -r requirements/base.in, epyqlib
 packaging==20.9           # via pint
 paho-mqtt==1.4.0          # via -r requirements/base.in, epyqlib
@@ -77,7 +78,6 @@ pytest-faulthandler==1.5.0  # via -r requirements/base.in
 pytest-qt==3.2.1          # via -r requirements/base.in
 pytest-rerunfailures==4.2  # via -r requirements/base.in
 pytest==3.9.2             # via -r requirements/base.in, pytest-faulthandler, pytest-qt, pytest-rerunfailures, pytest-twisted
-python-can==3.3.2         # via -r requirements/base.in, epyqlib
 python-dateutil==2.8.1    # via arrow, botocore
 python-docx==0.8.10       # via epyqlib
 python-dotenv==0.15.0     # via epyqlib
@@ -93,7 +93,7 @@ six==1.15.0               # via automat, pathlib2, pip-tools, pyopenssl, pytest,
 smmap==3.0.5              # via gitdb
 toml==0.10.2              # via black
 toolz==0.11.1             # via epcsunspecdemo
-tqdm==4.58.0              # via epcsunspecdemo
+tqdm==4.59.0              # via epcsunspecdemo
 treq==21.1.0              # via -r requirements/base.in, epyqlib
 twisted[tls]==21.2.0      # via -r requirements/base.in, epyqlib, qt5reactor, treq
 typed-ast==1.4.2          # via black
@@ -101,7 +101,7 @@ typing-extensions==3.7.4.3  # via black, importlib-metadata
 urllib3==1.25.11          # via botocore, dulwich, requests
 wheel==0.34.2             # via -r requirements/pre.in
 wrapt==1.12.1             # via python-can
-zipp==3.4.0               # via importlib-metadata
+zipp==3.4.1               # via importlib-metadata
 zope.interface==5.2.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/base.macos.txt
+++ b/requirements/base.macos.txt
@@ -13,7 +13,7 @@
 -e git+https://github.com/eliben/pyelftools@27941c50fef8cff8ef991419511664154c8cdf52#egg=pyelftools  # via -r requirements/base.in, epyqlib
 -e git+https://github.com/altendky/pysunspec@d8072a8e3c04693fe2a657a90fc9d303037dd91c#egg=pysunspec  # via -r requirements/base.in, epcsunspecdemo
 -e git+https://github.com/altendky/pytest-twisted@6f04ba3ad806b3b40602999e71c28633c36d81f9#egg=pytest-twisted  # via -r requirements/base.in
--e git+https://github.com/gordon-epc/python-can@f451343f8b0991ee96e0849ce3198cc38977cebe#egg=python-can  # via -r requirements/base.in, epyqlib
+-e git+https://github.com/hardbyte/python-can@2ede107d67002c18463c5276b6a94cdb19fc8320#egg=python-can  # via -r requirements/base.in, epyqlib
 -e git+https://github.com/altendky/qt5reactor@ce3ea2dad6d71adb10cde79b64bc0c7d27e9139c#egg=qt5reactor  # via -r requirements/base.in, epyqlib
 alqtendpy==0.0.4          # via -r requirements/base.in, epyqlib
 altendpy==0.0.21          # via alqtendpy
@@ -46,7 +46,7 @@ graham==0.1.11            # via -r requirements/base.in, epyqlib
 greenlet==1.0.0           # via pytest-twisted
 hyperlink==21.0.0         # via treq, twisted
 idna==2.10                # via hyperlink, requests, twisted
-importlib-metadata==3.7.2  # via pint
+importlib-metadata==3.7.3  # via pint
 incremental==21.3.0       # via treq, twisted
 jinja2==2.11.3            # via altendpy
 jmespath==0.10.0          # via boto3, botocore

--- a/requirements/base.macos.txt
+++ b/requirements/base.macos.txt
@@ -13,8 +13,8 @@
 -e git+https://github.com/eliben/pyelftools@27941c50fef8cff8ef991419511664154c8cdf52#egg=pyelftools  # via -r requirements/base.in, epyqlib
 -e git+https://github.com/altendky/pysunspec@d8072a8e3c04693fe2a657a90fc9d303037dd91c#egg=pysunspec  # via -r requirements/base.in, epcsunspecdemo
 -e git+https://github.com/altendky/pytest-twisted@6f04ba3ad806b3b40602999e71c28633c36d81f9#egg=pytest-twisted  # via -r requirements/base.in
+-e git+https://github.com/gordon-epc/python-can@f451343f8b0991ee96e0849ce3198cc38977cebe#egg=python-can  # via -r requirements/base.in, epyqlib
 -e git+https://github.com/altendky/qt5reactor@ce3ea2dad6d71adb10cde79b64bc0c7d27e9139c#egg=qt5reactor  # via -r requirements/base.in, epyqlib
-aenum==3.0.0              # via python-can
 alqtendpy==0.0.4          # via -r requirements/base.in, epyqlib
 altendpy==0.0.21          # via alqtendpy
 altgraph==0.17            # via macholib, pyinstaller
@@ -37,7 +37,7 @@ constantly==15.1.0        # via twisted
 cryptography==3.4.6       # via pyopenssl, service-identity
 decorator==4.4.2          # via pytest-twisted
 docutils==0.15.2          # via botocore
-dulwich==0.20.19          # via epyqlib
+dulwich==0.20.20          # via epyqlib
 fab==3.0.0                # via epyqlib
 future==0.18.2            # via canmatrix
 gitdb==4.0.5              # via gitpython
@@ -46,7 +46,7 @@ graham==0.1.11            # via -r requirements/base.in, epyqlib
 greenlet==1.0.0           # via pytest-twisted
 hyperlink==21.0.0         # via treq, twisted
 idna==2.10                # via hyperlink, requests, twisted
-importlib-metadata==3.7.0  # via pint
+importlib-metadata==3.7.2  # via pint
 incremental==21.3.0       # via treq, twisted
 jinja2==2.11.3            # via altendpy
 jmespath==0.10.0          # via boto3, botocore
@@ -55,7 +55,8 @@ macholib==1.14            # via pyinstaller
 markupsafe==1.1.1         # via jinja2
 marshmallow==2.21.0       # via graham
 more-itertools==8.7.0     # via pytest
-mypy-extensions==0.4.3    # via black
+msgpack==1.0.2            # via python-can
+mypy-extensions==0.4.3    # via black, python-can
 natsort==5.4.1            # via -r requirements/base.in, epyqlib
 packaging==20.9           # via pint
 paho-mqtt==1.4.0          # via -r requirements/base.in, epyqlib
@@ -79,7 +80,6 @@ pytest-faulthandler==1.5.0  # via -r requirements/base.in
 pytest-qt==3.2.1          # via -r requirements/base.in
 pytest-rerunfailures==4.2  # via -r requirements/base.in
 pytest==3.9.2             # via -r requirements/base.in, pytest-faulthandler, pytest-qt, pytest-rerunfailures, pytest-twisted
-python-can==3.3.2         # via -r requirements/base.in, epyqlib
 python-dateutil==2.8.1    # via arrow, botocore
 python-docx==0.8.10       # via epyqlib
 python-dotenv==0.15.0     # via epyqlib
@@ -95,7 +95,7 @@ six==1.15.0               # via automat, pathlib2, pip-tools, pyopenssl, pytest,
 smmap==3.0.5              # via gitdb
 toml==0.10.2              # via black
 toolz==0.11.1             # via epcsunspecdemo
-tqdm==4.58.0              # via epcsunspecdemo
+tqdm==4.59.0              # via epcsunspecdemo
 treq==21.1.0              # via -r requirements/base.in, epyqlib
 twisted[tls]==21.2.0      # via -r requirements/base.in, epyqlib, qt5reactor, treq
 typed-ast==1.4.2          # via black
@@ -103,7 +103,7 @@ typing-extensions==3.7.4.3  # via black, importlib-metadata
 urllib3==1.25.11          # via botocore, dulwich, requests
 wheel==0.34.2             # via -r requirements/pre.in
 wrapt==1.12.1             # via python-can
-zipp==3.4.0               # via importlib-metadata
+zipp==3.4.1               # via importlib-metadata
 zope.interface==5.2.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/base.windows.txt
+++ b/requirements/base.windows.txt
@@ -13,8 +13,8 @@
 -e git+https://github.com/eliben/pyelftools@27941c50fef8cff8ef991419511664154c8cdf52#egg=pyelftools  # via -r requirements\base.in, epyqlib
 -e git+https://github.com/altendky/pysunspec@d8072a8e3c04693fe2a657a90fc9d303037dd91c#egg=pysunspec  # via -r requirements\base.in, epcsunspecdemo
 -e git+https://github.com/altendky/pytest-twisted@6f04ba3ad806b3b40602999e71c28633c36d81f9#egg=pytest-twisted  # via -r requirements\base.in
+-e git+https://github.com/gordon-epc/python-can@f451343f8b0991ee96e0849ce3198cc38977cebe#egg=python-can  # via -r requirements\base.in, epyqlib
 -e git+https://github.com/altendky/qt5reactor@ce3ea2dad6d71adb10cde79b64bc0c7d27e9139c#egg=qt5reactor  # via -r requirements\base.in, epyqlib
-aenum==3.0.0              # via python-can
 alqtendpy==0.0.4          # via -r requirements\base.in, epyqlib
 altendpy==0.0.21          # via alqtendpy
 altgraph==0.17            # via pyinstaller
@@ -37,7 +37,7 @@ constantly==15.1.0        # via twisted
 cryptography==3.4.6       # via pyopenssl, service-identity
 decorator==4.4.2          # via pytest-twisted
 docutils==0.15.2          # via botocore
-dulwich==0.20.19          # via epyqlib
+dulwich==0.20.20          # via epyqlib
 fab==3.0.0                # via epyqlib
 future==0.18.2            # via canmatrix, pefile
 gitdb==4.0.5              # via gitpython
@@ -46,7 +46,7 @@ graham==0.1.11            # via -r requirements\base.in, epyqlib
 greenlet==1.0.0           # via pytest-twisted
 hyperlink==21.0.0         # via treq, twisted
 idna==2.10                # via hyperlink, requests, twisted
-importlib-metadata==3.7.0  # via pint
+importlib-metadata==3.7.2  # via pint
 incremental==21.3.0       # via treq, twisted
 jinja2==2.11.3            # via altendpy
 jmespath==0.10.0          # via boto3, botocore
@@ -54,7 +54,7 @@ lxml==4.6.2               # via python-docx
 markupsafe==1.1.1         # via jinja2
 marshmallow==2.21.0       # via graham
 more-itertools==8.7.0     # via pytest
-mypy-extensions==0.4.3    # via black
+mypy-extensions==0.4.3    # via black, python-can
 natsort==5.4.1            # via -r requirements\base.in, epyqlib
 packaging==20.9           # via pint
 paho-mqtt==1.4.0          # via -r requirements\base.in, epyqlib
@@ -79,12 +79,11 @@ pytest-faulthandler==1.5.0  # via -r requirements\base.in
 pytest-qt==3.2.1          # via -r requirements\base.in
 pytest-rerunfailures==4.2  # via -r requirements\base.in
 pytest==3.9.2             # via -r requirements\base.in, pytest-faulthandler, pytest-qt, pytest-rerunfailures, pytest-twisted
-python-can==3.3.2         # via -r requirements\base.in, epyqlib
 python-dateutil==2.8.1    # via arrow, botocore
 python-docx==0.8.10       # via epyqlib
 python-dotenv==0.15.0     # via epyqlib
 pywin32-ctypes==0.2.0     # via pyinstaller
-pywin32==223 ; sys_platform == "win32"  # via -r requirements\base.in
+pywin32==223 ; sys_platform == "win32"  # via -r requirements\base.in, python-can
 qtawesome==1.0.2          # via epyqlib
 qtpy==1.9.0               # via qtawesome
 regex==2020.11.13         # via black
@@ -97,7 +96,7 @@ six==1.15.0               # via automat, pathlib2, pip-tools, pyopenssl, pytest,
 smmap==3.0.5              # via gitdb
 toml==0.10.2              # via black
 toolz==0.11.1             # via epcsunspecdemo
-tqdm==4.58.0              # via epcsunspecdemo
+tqdm==4.59.0              # via epcsunspecdemo
 treq==21.1.0              # via -r requirements\base.in, epyqlib
 twisted-iocpsupport==1.0.1  # via twisted
 twisted[tls]==21.2.0      # via -r requirements\base.in, epyqlib, qt5reactor, treq
@@ -107,7 +106,7 @@ urllib3==1.25.11          # via botocore, dulwich, requests
 wheel==0.34.2             # via -r requirements\pre.in
 windows-curses==2.2.0     # via python-can
 wrapt==1.12.1             # via python-can
-zipp==3.4.0               # via importlib-metadata
+zipp==3.4.1               # via importlib-metadata
 zope.interface==5.2.0     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/base.windows.txt
+++ b/requirements/base.windows.txt
@@ -13,7 +13,7 @@
 -e git+https://github.com/eliben/pyelftools@27941c50fef8cff8ef991419511664154c8cdf52#egg=pyelftools  # via -r requirements\base.in, epyqlib
 -e git+https://github.com/altendky/pysunspec@d8072a8e3c04693fe2a657a90fc9d303037dd91c#egg=pysunspec  # via -r requirements\base.in, epcsunspecdemo
 -e git+https://github.com/altendky/pytest-twisted@6f04ba3ad806b3b40602999e71c28633c36d81f9#egg=pytest-twisted  # via -r requirements\base.in
--e git+https://github.com/gordon-epc/python-can@f451343f8b0991ee96e0849ce3198cc38977cebe#egg=python-can  # via -r requirements\base.in, epyqlib
+-e git+https://github.com/hardbyte/python-can@2ede107d67002c18463c5276b6a94cdb19fc8320#egg=python-can  # via -r requirements\base.in, epyqlib
 -e git+https://github.com/altendky/qt5reactor@ce3ea2dad6d71adb10cde79b64bc0c7d27e9139c#egg=qt5reactor  # via -r requirements\base.in, epyqlib
 alqtendpy==0.0.4          # via -r requirements\base.in, epyqlib
 altendpy==0.0.21          # via alqtendpy
@@ -46,7 +46,7 @@ graham==0.1.11            # via -r requirements\base.in, epyqlib
 greenlet==1.0.0           # via pytest-twisted
 hyperlink==21.0.0         # via treq, twisted
 idna==2.10                # via hyperlink, requests, twisted
-importlib-metadata==3.7.2  # via pint
+importlib-metadata==3.7.3  # via pint
 incremental==21.3.0       # via treq, twisted
 jinja2==2.11.3            # via altendpy
 jmespath==0.10.0          # via boto3, botocore

--- a/requirements/pre.linux.txt
+++ b/requirements/pre.linux.txt
@@ -12,7 +12,7 @@ pip-tools==5.1.0          # via -r requirements/pre.in
 requests==2.25.1          # via romp
 romp==2020.3              # via -r requirements/pre.in
 six==1.15.0               # via pip-tools
-urllib3==1.26.3           # via requests
+urllib3==1.26.4           # via requests
 wheel==0.34.2             # via -r requirements/pre.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pre.macos.txt
+++ b/requirements/pre.macos.txt
@@ -12,7 +12,7 @@ pip-tools==5.1.0          # via -r requirements/pre.in
 requests==2.25.1          # via romp
 romp==2020.3              # via -r requirements/pre.in
 six==1.15.0               # via pip-tools
-urllib3==1.26.3           # via requests
+urllib3==1.26.4           # via requests
 wheel==0.34.2             # via -r requirements/pre.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pre.windows.txt
+++ b/requirements/pre.windows.txt
@@ -12,7 +12,7 @@ pip-tools==5.1.0          # via -r requirements\pre.in
 requests==2.25.1          # via romp
 romp==2020.3              # via -r requirements\pre.in
 six==1.15.0               # via pip-tools
-urllib3==1.26.3           # via requests
+urllib3==1.26.4           # via requests
 wheel==0.34.2             # via -r requirements\pre.in
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Add the feature to show the PCAN device ID/number in the EPyQ interface. As part of this task, attempt to add code to python-can.