### PR TITLE
ci (SC-5421): bump GitHub Actions to Node 24 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,16 +25,16 @@ jobs:
     name: CI
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -102,7 +102,7 @@ jobs:
           poetry build
           poetry publish --repository epc-power
       - name: Archive artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: epyq_st
           path: |


### PR DESCRIPTION
## Summary

- Bump four pinned GitHub Actions in `.github/workflows/ci.yml` from Node 20-runtime majors to versions whose `runs.using` is `node24`, eliminating the deprecation warnings tracked by [SC-5421](https://epcpower.atlassian.net/browse/SC-5421):
  - `actions/checkout` v4 → v6
  - `actions/setup-python` v5 → v6
  - `aws-actions/configure-aws-credentials` v4 → v6
  - `actions/upload-artifact` v4 → v7
- Bump `sub/epyqlib` submodule pointer.

Pins use the floating major tag, matching the existing style in this file. The repo's Actions allowlist (`github_owned_allowed: true`, `aws-actions/*` patterns allowed) already permits all four. No workflow inputs needed adjustment — checked against the v4→v6/v7 breaking-change notes (boolean-input handling for `configure-aws-credentials`, ESM migration for `upload-artifact`, runner-minimum bumps); none affect this workflow, which runs on the GitHub-hosted `windows-2022` image.

## Test plan

- [ ] CI run on this branch is green
- [ ] No `Node.js ... is deprecated` annotations appear on the run
- [ ] Each upgraded step header shows the new version (`Run actions/checkout@v6`, etc.)
- [ ] `epyq_st` artifact is still uploaded successfully

[SC-5421]: https://epcpower.atlassian.net/browse/SC-5421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ